### PR TITLE
linux flag: MSG_NOSIGNAL

### DIFF
--- a/Source/ScsSendQueue.cpp
+++ b/Source/ScsSendQueue.cpp
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 #include "ScsInternal.h"
 
+#ifdef SCS_WINDOWS
+#	define MSG_NOSIGNAL 0
+#endif
+
 using namespace Scs;
 
 
@@ -39,7 +43,7 @@ bool SendQueue::Send(SocketPtr socket)
 	assert(!m_queue.empty());
 	auto buffer = m_queue.front();
 	size_t bytesSent = 0;
-	if (!socket->Send(buffer->data() + m_bytesSent, buffer->size() - m_bytesSent, 0, &bytesSent))
+	if (!socket->Send(buffer->data() + m_bytesSent, buffer->size() - m_bytesSent, MSG_NOSIGNAL, &bytesSent))
 		return false;
 	m_bytesSent += bytesSent;
 	if (m_bytesSent == buffer->size())


### PR DESCRIPTION
fixes https://github.com/JamesBoer/Scs/issues/5

pass MSG_NOSIGNAL to send() in linux systems.

https://stackoverflow.com/questions/5382940/broken-pipe-when-socket-is-closed 